### PR TITLE
Changed AWSLambdaReadOnlyAccess to AWSLambda_ReadOnlyAccess

### DIFF
--- a/template-mvn.yml
+++ b/template-mvn.yml
@@ -17,7 +17,7 @@ Resources:
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
-        - AWSLambdaReadOnlyAccess
+        - AWSLambda_ReadOnlyAccess
         - AWSXrayWriteOnlyAccess
         - AWSLambdaVPCAccessExecutionRole
         - AmazonS3FullAccess


### PR DESCRIPTION
Changed AWSLambdaReadOnlyAccess to AWSLambda_ReadOnlyAccess to reflect correct name for the policy

The policy name was changed on March 1st, please see here for more information:
https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
